### PR TITLE
add a configuration file for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install deb dependencies
-        run: sudo apt-get install -y xorg-dev libglu1-mesa-dev libglew-dev
+        run: sudo apt-get install -y xorg-dev libglu1-mesa-dev libglew-dev xvfb
       - name: Install python dependencies
         run: pip install -r requirements.txt
       - name: Cache python wheel packages
@@ -41,4 +41,4 @@ jobs:
       - name: Install evolution gym
         run: pip install -e .
       - name: Run test
-        run: python -c 'import evogym; print(f"{evogym.__name__} was loaded.")'
+        run: xvfb-run python -m unittest tests/test_render.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Testing
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Install deb dependencies
+        run: sudo apt-get install -y xorg-dev libglu1-mesa-dev libglew-dev
+      - name: Install python dependencies
+        run: pip install -r requirements.txt
+      - name: Cache python wheel packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: wheel-cache-${{ hashFiles('requirements.txt') }}
+      - name: Install evolution gym
+        run: pip install -e .
+      - name: Run test
+        run: python -c 'import evogym; print(f"{evogym.__name__} was loaded.")'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     strategy:
       matrix:
+        os:
+          - "ubuntu-22.04"
+          - "ubuntu-latest"
         python:
           - "3.7"
           - "3.8"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,21 @@ concurrency:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        python:
+          - "3.7"
+          - "3.8"
+          - "3.9"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python }}
       - name: Install deb dependencies
         run: sudo apt-get install -y xorg-dev libglu1-mesa-dev libglew-dev
       - name: Install python dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -7,12 +7,12 @@ dependencies:
   - pip:
     - glfw==2.5.0
     - gpy==1.10.0
-    - git+git://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
+    - git+https://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
     - gym==0.19.0
     - h5py==3.6.0
     - imageio==2.14.1
     - matplotlib==3.5.1
-    - git+git://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414d4922603e904
+    - git+https://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414d4922603e904
     - numpy==1.21.5
     - opencv-python==4.5.5.62
     - pillow==9.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 glfw==2.5.0
 GPy==1.10.0
-GPyOpt @ git+git://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414d4922603e904
+GPyOpt @ git+https://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414d4922603e904
 gym==0.19.0
 h5py==3.6.0
 imageio==2.14.1
 matplotlib==3.5.1
-neat-python @ git+git://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
+neat-python @ git+https://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
 numpy==1.21.5
 opencv-python==4.5.5.62
 Pillow==9.0.0

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+import evogym.envs
+import gym
+from evogym import sample_robot
+
+
+class RenderTest(TestCase):
+    def test_it(self):
+        body, connections = sample_robot((5, 5))
+        env = gym.make("Walker-v0", body=body)
+        env.reset()
+
+        for _ in range(100):
+            action = env.action_space.sample() - 1
+            ob, reward, done, info = env.step(action)
+            env.render()
+
+            if done:
+                env.reset()
+
+        env.close()


### PR DESCRIPTION
Add a configuration file for CI.

For CI, we use ubuntu-22.04 as the operating system and confirm that Evolution Gym can be installed. The current Evolution Gym does not have unittests, so tests will not be executed. However, we confirm that the evogym package can be imported. This allows us to confirm both building and importing of the simulator.

We will use Github Actions for CI. From my research, it seems that Github Actions can be used for free if the repository is open source and we use Github's public runners. As a result, we chose Github Actions because it was easy to set up.

https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions

When using pip install -r requirements.txt on Github Actions without authentication credentials, the installation of GPyOpt and neat-python, which are directly installed from Github, failed. Therefore, I changed the download method to use HTTPS instead. Is this okay? I would like to hear your opinion.
