### PR TITLE
Use pip for installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.8-bullseye
+USER root
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends xorg-dev libglu1-mesa-dev libglew-dev
+WORKDIR /project
+COPY . /project/evogym
+RUN pip install --upgrade pip
+RUN pip install -r /project/evogym/requirements.txt
+RUN pip install /project/evogym/

--- a/README.md
+++ b/README.md
@@ -23,23 +23,19 @@ git clone --recurse-submodules https://github.com/EvolutionGym/evogym.git
 
 <!--- (See [installation instructions](#opengl-installation-on-unix-based-systems) on Unix based systems) --->
 
-On **Linux only**:
+### Running with Docker
+
+A Dockerfile is provided which can be used to build an image. Alternatively, a prebuilt version of this image is available on Dockerhub:
 
 ```shell
-sudo apt-get install xorg-dev libglu1-mesa-dev
+docker pull dennisgwilson/evogym
+docker run -it -p 8888:8888 evoimage
 ```
 
-Either install Python dependencies with conda:
+Your container should include a python shell with evogym installed. To run using jupyter, find the container name (`docker ps`) and run the following:
 
 ```shell
-conda env create -f environment.yml
-conda activate evogym
-```
-
-or with pip:
-
-```shell
-pip install -r requirements.txt
+docker exec <CONTAINER_NAME> jupyter notebook --ip 0.0.0.0 --no-browser --allow-root
 ```
 
 ### Build and Install Package
@@ -47,6 +43,7 @@ pip install -r requirements.txt
 To build the C++ simulation, build all the submodules, and install `evogym` run the following command:
 
 ```shell
+pip install -r requirements.txt
 pip install .
 ``` 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install -r requirements.txt
 To build the C++ simulation, build all the submodules, and install `evogym` run the following command:
 
 ```shell
-python setup.py install
+pip install .
 ``` 
 
 ### Test Installation

--- a/README.md
+++ b/README.md
@@ -25,11 +25,22 @@ git clone --recurse-submodules https://github.com/EvolutionGym/evogym.git
 
 ### Running with Docker
 
-A Dockerfile is provided which can be used to build an image. Alternatively, a prebuilt version of this image is available on Dockerhub:
+A Dockerfile is provided which can be used to build an image:
+
+```shell
+docker build -t evogym .
+```
+
+Alternatively, a prebuilt version of this image is available on Dockerhub:
 
 ```shell
 docker pull dennisgwilson/evogym
-docker run -it -p 8888:8888 evoimage
+```
+
+Once the image `evogym` is installed, it can be run using:
+
+```shell
+docker run -it -p 8888:8888 evogym
 ```
 
 Your container should include a python shell with evogym installed. To run using jupyter, find the container name (`docker ps`) and run the following:

--- a/environment.yml
+++ b/environment.yml
@@ -5,10 +5,9 @@ dependencies:
   - python=3.7.11
   - pip
   - pip:
-    - glfw==2.5.0
+    - glfw==1.8.6
     - gpy==1.10.0
-    - git+https://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
-    - gym==0.19.0
+    - gym==0.22.0
     - h5py==3.6.0
     - imageio==2.14.1
     - matplotlib==3.5.1
@@ -17,11 +16,8 @@ dependencies:
     - opencv-python==4.5.5.62
     - pillow==9.0.0
     - pybind11==2.9.0
-    - pygifsicle==1.0.5
     - pyopengl==3.1.5
     - pyopengl-accelerate==3.1.5
-    - stable-baselines3==1.4.0
-    - torch==1.10.2
     - ttkbootstrap==1.5.1
     - typing==3.7.4.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "pybind11>=2.6.0"]
+requires = ["setuptools", "cmake", "wheel", "pybind11>=2.6.0"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,14 +5,11 @@ gym==0.22.0
 h5py==3.6.0
 imageio==2.14.1
 matplotlib==3.5.1
-neat-python @ git+https://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
 numpy==1.21.5
 opencv-python==4.5.5.62
 Pillow==9.0.0
 pybind11==2.9.0
-pygifsicle==1.0.5
 PyOpenGL==3.1.5
 PyOpenGL-accelerate==3.1.5
-torch==1.10.2
 ttkbootstrap==1.5.1
 typing==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ GPyOpt @ git+https://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414
 gym==0.22.0
 h5py==3.6.0
 imageio==2.14.1
+jupyter==1.0.0
 matplotlib==3.5.1
 numpy==1.21.5
 opencv-python==4.5.5.62
@@ -12,4 +13,6 @@ pybind11==2.9.0
 PyOpenGL==3.1.5
 PyOpenGL-accelerate==3.1.5
 ttkbootstrap==1.5.1
+torch==1.10.2
+tqdm==4.62.3
 typing==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-glfw==2.5.0
+glfw==1.8.6
 GPy==1.10.0
 GPyOpt @ git+https://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414d4922603e904
-gym==0.19.0
+gym==0.22.0
 h5py==3.6.0
 imageio==2.14.1
 matplotlib==3.5.1
@@ -13,7 +13,6 @@ pybind11==2.9.0
 pygifsicle==1.0.5
 PyOpenGL==3.1.5
 PyOpenGL-accelerate==3.1.5
-stable-baselines3==1.4.0
 torch==1.10.2
 ttkbootstrap==1.5.1
 typing==3.7.4.3


### PR DESCRIPTION
`python setup.py install` is deprecated in favor of installation with `pip`. The use of `setup.py` appears to be responsible for compilation and linking errors with the simulator (#13). The proposed changes do the following:

- add `cmake` to the build system requirements in `pyproject.toml`
- use a consistent and reduced set of dependencies which work with `pip` 23
- recommend `pip` installation in  `README.md`