### PR TITLE
Bump gym version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+      - name: Update deb repository
+        run: sudo apt-get update
       - name: Install deb dependencies
         run: sudo apt-get install -y xorg-dev libglu1-mesa-dev libglew-dev xvfb
       - name: Install python dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - glfw==2.5.0
     - gpy==1.10.0
     - git+https://github.com/yunshengtian/neat-python@2762ab630838520ca6c03a866e8a158f592b0370
-    - gym==0.19.0
+    - gym==0.22.0
     - h5py==3.6.0
     - imageio==2.14.1
     - matplotlib==3.5.1
@@ -20,7 +20,6 @@ dependencies:
     - pygifsicle==1.0.5
     - pyopengl==3.1.5
     - pyopengl-accelerate==3.1.5
-    - stable-baselines3==1.4.0
     - torch==1.10.2
     - ttkbootstrap==1.5.1
     - typing==3.7.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 glfw==2.5.0
 GPy==1.10.0
 GPyOpt @ git+https://github.com/yunshengtian/GPyOpt@5fc1188ffdefea9a3bc7964a9414d4922603e904
-gym==0.19.0
+gym==0.22.0
 h5py==3.6.0
 imageio==2.14.1
 matplotlib==3.5.1
@@ -13,7 +13,6 @@ pybind11==2.9.0
 pygifsicle==1.0.5
 PyOpenGL==3.1.5
 PyOpenGL-accelerate==3.1.5
-stable-baselines3==1.4.0
 torch==1.10.2
 ttkbootstrap==1.5.1
 typing==3.7.4.3


### PR DESCRIPTION
CI with Github Actions was starting to fail.
Therefore, we have fixed the following issues.
  
- Update apt repository (github actions)
- Update gym version to 0.22.0
- Since stable-baseline3 is installed with gym, it has been removed from requirements.txt.

It contains a fix similar to the pull request below.
https://github.com/EvolutionGym/evogym/pull/27

However, this pull request (#30) has a smaller impact than #27.
