### PR TITLE
fix GLEW library build configuration

### DIFF
--- a/evogym/simulator/CMakeLists.txt
+++ b/evogym/simulator/CMakeLists.txt
@@ -19,6 +19,9 @@ endif()
 
 if(UNIX)
   find_package(OpenGL REQUIRED)
+  set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR})  # use custom FindGLEW.cmake
+  set(GLEW_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/externals/glew/include)
+  set(GLEW_LIBRARY ${PROJECT_SOURCE_DIR}/externals/glew/lib/libGLEW.*)
   find_package(GLEW REQUIRED)
 endif()
 
@@ -46,4 +49,3 @@ add_subdirectory(SimulatorCPP/)
 
 set(CMAKE_CXX_STANDARD_LIBRARIES -ldl)
 # set(CMAKE_VERBOSE_MAKEFILE ON)
-

--- a/evogym/simulator/FindGLEW.cmake
+++ b/evogym/simulator/FindGLEW.cmake
@@ -1,0 +1,23 @@
+# FindGLEW.cmake
+# Search for GLEW library and include directories
+
+find_path(GLEW_INCLUDE_DIR GL/glew.h)
+find_library(GLEW_LIBRARY NAMES GLEW GLEW32)
+
+if (GLEW_INCLUDE_DIR AND GLEW_LIBRARY)
+    set(GLEW_FOUND TRUE)
+else()
+    set(GLEW_FOUND FALSE)
+endif()
+
+if (GLEW_FOUND)
+    if (NOT GLEW_FIND_QUIETLY)
+        message(STATUS "Found GLEW: ${GLEW_LIBRARY}")
+    endif ()
+else()
+    if (GLEW_FIND_REQUIRED)
+        message(FATAL_ERROR "Could NOT find GLEW")
+    endif ()
+endif()
+
+mark_as_advanced(GLEW_INCLUDE_DIR GLEW_LIBRARY)


### PR DESCRIPTION
Depending on the version of cmake, it may not be possible to search for GLEW, which is a submodule. This phenomenon may occur on macOS.

There seems to be a problem with FindGLEW.cmake provided by Cmake. In order to independently search for GLEW at a unique location, I decided to simply add and use FindGLEW.cmake. In my environment, this allows me to explore GLEW for submodules.

Cmake version 3.27.1 (install by homebrew)

this pull request includes https://github.com/EvolutionGym/evogym/pull/30 commits (for passing ci tests)
